### PR TITLE
make sendmail customizable

### DIFF
--- a/journal-mailer.config.example
+++ b/journal-mailer.config.example
@@ -12,3 +12,5 @@ receiver_map:
 
 context_interval: 5  # how many seconds of previous logs from the unit to include
 
+sendmail_path: /usr/sbin/sendmail # optional
+sendmail_opts: []                 # optional

--- a/test/OptionsSpec.hs
+++ b/test/OptionsSpec.hs
@@ -67,6 +67,8 @@ spec = do
         options <- withArgs ["--config", configFile] $ getConfiguration
         options `shouldBe` Configuration {
           showHelp = False,
+          sendmailPath = Nothing,
+          sendmailOpts = Nothing,
           sender = "sender@example.com",
           receivers =
             "receiver1@example.com" :

--- a/test/ProcessSpec.hs
+++ b/test/ProcessSpec.hs
@@ -31,6 +31,8 @@ main = hspec spec
 options :: Configuration String
 options = Configuration {
   showHelp = False,
+  sendmailPath = Nothing,
+  sendmailOpts = Nothing,
   sender = "foo@bar",
   receivers = ["fakeReceiver@bar"],
   receiverMap = empty,


### PR DESCRIPTION
With this patch the path and arguments of sendmail can be configured (through the configuration file).

In particular this enables convenient integration of sendmail-alternatives that need extra arguments, like e.g. ssmtp, into systems that don't have `/usr/sbin`, like e.g. NixOS. 
